### PR TITLE
docs: fix typos, casing, alias syntax, and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Specifically, this project helps
 
 -   scaffold new projects
 -   maintain dependencies, which may mix different language ecosystems
--   generate Github-oriented documentation with evaluated code blocks
+-   generate GitHub-oriented documentation with evaluated code blocks
 -   build and distribute packages, binary or otherwise
 -   document Nix and recommended practices for absolute beginners.
 

--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ Specifically, this project helps
 
 - scaffold new projects
 - maintain dependencies, which may mix different language ecosystems
-- generate Github-oriented documentation with evaluated code blocks
+ - generate GitHub-oriented documentation with evaluated code blocks
 - build and distribute packages, binary or otherwise
 - document Nix and recommended practices for absolute beginners.
 

--- a/doc/internal/params.el
+++ b/doc/internal/params.el
@@ -15,5 +15,5 @@
  (nixos-latest         . "25.05")
  (platforms            . "\n\
 - Linux on x86-64 machines\n\
-- MacOS on x86-64 machines\n\
-- MacOS on ARM64 machines (M1 or M2)"))
+- macOS on x86-64 machines\n\
+- macOS on ARM64 machines (M1 or M2)"))

--- a/doc/nix-installation.md
+++ b/doc/nix-installation.md
@@ -24,8 +24,8 @@ If you're unsure if you want to enable flakes or not, read the provided [introdu
 This project supports
 
 -   Linux on x86-64 machines
--   MacOS on x86-64 machines
--   MacOS on ARM64 machines (M1 or M2).
+-   macOS on x86-64 machines
+-   macOS on ARM64 machines (M1 or M2).
 
 All we need to use this project is to install Nix, which this document covers. Nix can be installed on a variety of Linux and Mac systems. Nix can also be installed in Windows via the Windows Subsystem for Linux (WSL). Installation on WSL may involve steps not covered in this documentation, though.
 
@@ -71,7 +71,7 @@ The Nix manual describes [other methods of installing Nix](https://nixos.org/man
 
 This project pushes built Nix packages to two substituters, [Garnix](https://garnix.io) and [Cachix](https://cachix.org), as part of its continuous integration. It's recommended to install at least one of these. Configuring both to have a fallback works as well. Garnix caches a few more packages than Cachix. Both should have similar availability.
 
-We need to extend two settings in either the system-level Nix configuration file at `/etc/nix/nix.conf`, or the user-level configuration at `~/.config/nix/nix.config` (which may not exist yet).
+We need to extend two settings in either the system-level Nix configuration file at `/etc/nix/nix.conf`, or the user-level configuration at `~/.config/nix/nix.conf` (which may not exist yet).
 
 The choice of whether to perform these settings system-level or user-level is up to your preference.
 
@@ -117,7 +117,7 @@ nix show-config substituters
 nix show-config trusted-public-keys
 ```
 
-Make sure still have settings for <https://cache.nixos.org>.
+Make sure you still have settings for <https://cache.nixos.org>.
 
 # Setting up experimental features<a id="sec-6"></a>
 
@@ -130,10 +130,10 @@ The provided [introduction to Nix](nix-introduction.md) covers in detail what th
 
 As you can guess, the `flakes` feature enables flakes functionality in Nix. The `nix-command` feature enables a variety of subcommands of Nix's newer `nix` command-line tool, some of which allow us to work with flakes.
 
-If you don't enable experimental features globally, there is a option to enable features local to just a single command-line invocation. For example, to use flakes-related commands, we call `nix --extra-experimental-features 'nix-command flakes' …`. When not configuring globally, setting an alias for this can be useful. The following command illustrates setting an alias in most POSIX-compliant shells:
+If you don't enable experimental features globally, there is an option to enable features local to just a single command-line invocation. For example, to use flakes-related commands, we call `nix --extra-experimental-features 'nix-command flakes' …`. When not configuring globally, setting an alias for this can be useful. The following command illustrates setting an alias in most POSIX-compliant shells:
 
 ```sh
-alias nix-flakes = nix --extra-experimental-features 'nix-command flakes'
+alias nix-flakes='nix --extra-experimental-features "nix-command flakes"'
 ```
 
 As discussed in the introduction, `nix-command` is enabled by default. You don't need to enable it explicitly (though you could disable it).

--- a/doc/nix-installation.org
+++ b/doc/nix-installation.org
@@ -114,7 +114,7 @@ more packages than Cachix. Both should have similar availability.
 
 We need to extend two settings in either the system-level Nix configuration file
 at =/etc/nix/nix.conf=, or the user-level configuration at
-=~/.config/nix/nix.config= (which may not exist yet).
+=~/.config/nix/nix.conf= (which may not exist yet).
 
 The choice of whether to perform these settings system-level or user-level is up
 to your preference.
@@ -172,7 +172,7 @@ nix show-config substituters
 nix show-config trusted-public-keys
 #+end_src
 
-Make sure still have settings for https://cache.nixos.org.
+Make sure you still have settings for https://cache.nixos.org.
 
 * Setting up experimental features
 
@@ -195,7 +195,7 @@ useful. The following command illustrates setting an alias in most
 POSIX-compliant shells:
 
 #+begin_src sh :eval no
-alias nix-flakes = nix --extra-experimental-features 'nix-command flakes'
+alias nix-flakes='nix --extra-experimental-features "nix-command flakes"'
 #+end_src
 
 As discussed in the introduction, =nix-command= is enabled by default. You don't

--- a/doc/nix-introduction.md
+++ b/doc/nix-introduction.md
@@ -229,7 +229,7 @@ If you write scripts that call `nix` commands or use flakes, they may break slig
 By calling `nix` with a few extra arguments `--extra-experimental-features 'nix-command flakes'` we can access flakes commands for single invocations without enabling flakes globally. You can even make an alias for your shell that might look like the following:
 
 ```sh
-alias nix-flakes = nix --extra-experimental-features 'nix-command flakes'
+alias nix-flakes='nix --extra-experimental-features "nix-command flakes"'
 ```
 
 This way, there's less to type interactively. Just don't script against this command, so there's no worry of scripts breaking due to experimental features.

--- a/doc/nix-introduction.org
+++ b/doc/nix-introduction.org
@@ -433,7 +433,7 @@ without enabling flakes globally. You can even make an alias for your shell that
 might look like the following:
 
 #+begin_src sh :eval no
-alias nix-flakes = nix --extra-experimental-features 'nix-command flakes'
+alias nix-flakes='nix --extra-experimental-features "nix-command flakes"'
 #+end_src
 
 This way, there's less to type interactively. Just don't script against this

--- a/doc/nix-usage-flakes.md
+++ b/doc/nix-usage-flakes.md
@@ -36,8 +36,8 @@ If you're new to Nix consider reading the provided [introduction](nix-introducti
 This project supports
 
 -   Linux on x86-64 machines
--   MacOS on x86-64 machines
--   MacOS on ARM64 machines (M1 or M2).
+-   macOS on x86-64 machines
+-   macOS on ARM64 machines (M1 or M2).
 
 That may affect your ability to follow along with examples.
 
@@ -46,7 +46,7 @@ Otherwise, see the provided [Nix installation and configuration guide](nix-insta
 To continue following this usage guide, you will need Nix's experimental flakes feature. You can enable this globally or use an alias such as the following:
 
 ```sh
-alias nix-flakes = nix --extra-experimental-features 'nix-command flakes'
+alias nix-flakes='nix --extra-experimental-features "nix-command flakes"'
 ```
 
 # Working with Nix<a id="sec-4"></a>

--- a/doc/nix-usage-flakes.org
+++ b/doc/nix-usage-flakes.org
@@ -98,7 +98,7 @@ To continue following this usage guide, you will need Nix's experimental flakes
 feature. You can enable this globally or use an alias such as the following:
 
 #+begin_src sh :eval no
-alias nix-flakes = nix --extra-experimental-features 'nix-command flakes'
+alias nix-flakes='nix --extra-experimental-features "nix-command flakes"'
 #+end_src
 
 * Working with Nix

--- a/doc/nix-usage-noflakes.md
+++ b/doc/nix-usage-noflakes.md
@@ -39,8 +39,8 @@ If you're new to Nix consider reading the provided [introduction](nix-introducti
 This project supports
 
 -   Linux on x86-64 machines
--   MacOS on x86-64 machines
--   MacOS on ARM64 machines (M1 or M2).
+-   macOS on x86-64 machines
+-   macOS on ARM64 machines (M1 or M2).
 
 That may affect your ability to follow along with examples.
 

--- a/doc/project-developing-basics.md
+++ b/doc/project-developing-basics.md
@@ -59,7 +59,7 @@ We can scaffold a project with the `less` template with the following command:
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#less \
-    /tmp/my-project-less  # or whereever you want your new project
+    /tmp/my-project-less  # or wherever you want your new project
 ```
 
     wrote: "/tmp/my-project-less/README.org"
@@ -86,7 +86,7 @@ nix develop
     
       menu            - prints this menu
       project-check   - run all checks/tests/linters
-      project-doc-gen - generate Github Markdown from Org files
+      project-doc-gen - generate GitHub Markdown from Org files
       project-format  - format all files in one command
 
 `project-doc-gen` generates documentation tailored for repositories hosted on GitHub. It uses the `org2gfm` script/library provided by Nix-project and is discussed in [another document](project-documenting.md).

--- a/doc/project-developing-basics.org
+++ b/doc/project-developing-basics.org
@@ -108,7 +108,7 @@ We can scaffold a project with the =less= template with the following command:
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#less \
-    /tmp/my-project-less  # or whereever you want your new project
+    /tmp/my-project-less  # or wherever you want your new project
 #+end_src
 
 #+name: scaffold-less
@@ -160,7 +160,7 @@ nix develop /tmp/my-project-less#default \
 : 
 :   menu            - prints this menu
 :   project-check   - run all checks/tests/linters
-:   project-doc-gen - generate Github Markdown from Org files
+:   project-doc-gen - generate GitHub Markdown from Org files
 :   project-format  - format all files in one command
 : 
 

--- a/doc/project-developing-modules.md
+++ b/doc/project-developing-modules.md
@@ -13,11 +13,11 @@
 
 # About this document<a id="sec-1"></a>
 
-This document is a continuation of [Flakes Basics Development Guide](project-developing-basics.md). Specifically, it explains how to use and author your own [`flake-parts`](https://github.com/hercules-ci/flake-parts) modules, to address some points of tension when using the plain flakes API.
+This document is a continuation of [Flakes Basic Development Guide](project-developing-basics.md). Specifically, it explains how to use and author your own [`flake-parts`](https://github.com/hercules-ci/flake-parts) modules, to address some points of tension when using the plain flakes API.
 
 # Prerequisites<a id="sec-2"></a>
 
-Before diving into flake-parts modules, you should be familiar with the [Flakes Basics Development Guide](project-developing-basics.md).
+Before diving into flake-parts modules, you should be familiar with the [Flakes Basic Development Guide](project-developing-basics.md).
 
 Additionally, the following guides may be helpful:
 
@@ -27,13 +27,13 @@ Additionally, the following guides may be helpful:
 
 # Scaffolding<a id="sec-3"></a>
 
-If you followed the [Flakes Basics Development Guide](project-developing-basics.md), you already scaffolded a project using the provided `less` template, which by design doesn't use `flake-parts`. To follow along with this guide, you can scaffold a project from the `more` template, which illustrates usage of `flake-parts`:
+If you followed the [Flakes Basic Development Guide](project-developing-basics.md), you already scaffolded a project using the provided `less` template, which by design doesn't use `flake-parts`. To follow along with this guide, you can scaffold a project from the `more` template, which illustrates usage of `flake-parts`:
 
 ```sh
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#more \
-    /tmp/my-project-more  # or whereever you want your new project
+    /tmp/my-project-more  # or wherever you want your new project
 ```
 
     wrote: "/tmp/my-project-more/README.org"
@@ -50,7 +50,7 @@ Beyond what's in the `less` template, the `more` template also provides two file
 
 # Motivating using `flake-parts`<a id="sec-4"></a>
 
-As covered in the [Flakes Basics Development Guide](project-developing-basics.md), the code in our `less` template has a few points of tension:
+As covered in the [Flakes Basic Development Guide](project-developing-basics.md), the code in our `less` template has a few points of tension:
 
 -   The `forAllSystems` boilerplate in [`flake.nix`](../examples/less/flake.nix), while not too many lines, is distracting.
 -   Lots of dependencies in [`nix/overlay.nix`](../examples/less/nix/overlay.nix) seem to build slightly differently and we have to figure out how to place their results in the appropriate flake output.

--- a/doc/project-developing-modules.org
+++ b/doc/project-developing-modules.org
@@ -43,14 +43,14 @@ rm --recursive --force /tmp/my-project-more
 
 * About this document
 
-This document is a continuation of [[file:project-developing-basics.org][Flakes Basics Development Guide]].
+This document is a continuation of [[file:project-developing-basics.org][Flakes Basic Development Guide]].
 Specifically, it explains how to use and author your own [[flake-parts][=flake-parts=]] modules,
 to address some points of tension when using the plain flakes API.
 
 * Prerequisites
 
 Before diving into flake-parts modules, you should be familiar with the [[file:project-developing-basics.org][Flakes
-Basics Development Guide]].
+Basic Development Guide]].
 
 Additionally, the following guides may be helpful:
 - [[file:nix-introduction.org][Introduction to Nix and Motivations to Use It]]
@@ -59,7 +59,7 @@ Additionally, the following guides may be helpful:
 
 * Scaffolding
 
-If you followed the [[file:project-developing-basics.org][Flakes Basics Development Guide]], you already scaffolded a
+If you followed the [[file:project-developing-basics.org][Flakes Basic Development Guide]], you already scaffolded a
 project using the provided =less= template, which by design doesn't use
 =flake-parts=.  To follow along with this guide, you can scaffold a project from
 the =more= template, which illustrates usage of =flake-parts=:
@@ -68,7 +68,7 @@ the =more= template, which illustrates usage of =flake-parts=:
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#more \
-    /tmp/my-project-more  # or whereever you want your new project
+    /tmp/my-project-more  # or wherever you want your new project
 #+end_src
 
 #+name: scaffold-more

--- a/doc/project-documenting.md
+++ b/doc/project-documenting.md
@@ -17,7 +17,7 @@
 
 # About this document<a id="sec-1"></a>
 
-This document shows one way to document your code with the `org2gfm` script provided by this project, Nix-project. This script converts [Emac's Org-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html) files into [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/). It can evaluate all source blocks in the Org files to generate results to include in the documentation or check that source code snippets work as intended.
+This document shows one way to document your code with the `org2gfm` script provided by this project, Nix-project. This script converts [Emacs' Org-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html) files into [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/). It can evaluate all source blocks in the Org files to generate results to include in the documentation or check that source code snippets work as intended.
 
 If you're reading this document right now as Markdown it was generated with `org2gfm`.
 
@@ -31,7 +31,7 @@ Finally, this document explains `org2gfm`'s design decisions and recommends a st
 
 Documenting programming projects often requires embedding code snippets. We generally want to check that these snippets are well-formed. Other times, we might want to process the code to obtain a result to embed in the document.
 
-Some may recognize this as similar to [literate programming](https://en.wikipedia.org/wiki/Literate_programming). The Emacs text editor has long has long shipped with a feature called [Org-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html) used for this kind of documentation. The Org-mode input files used by `org2gfm` are more-or-less human-readable markdown files, though they support a lot of features for document processing.
+Some may recognize this as similar to [literate programming](https://en.wikipedia.org/wiki/Literate_programming). The Emacs text editor has long shipped with a feature called [Org-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html) used for this kind of documentation. The Org-mode input files used by `org2gfm` are more-or-less human-readable markdown files, though they support a lot of features for document processing.
 
 Emacs can be run in a headless mode from the command-line to avoid bringing up an entire text editor to generate documentation. This is what `org2gfm` does. The script manages the execution of Emacs on the user's behalf.
 
@@ -57,7 +57,7 @@ If you want to integrate documentation generation with a project scaffolded by N
 
 # Usage<a id="sec-4"></a>
 
-> **<span class="underline">WARNING</span>**: Since =org2gfm by default writes over files in-place, source control is highly recommended to protect against the loss of documentation.
+> **<span class="underline">WARNING</span>**: Since =org2gfm= by default writes over files in-place, source control is highly recommended to protect against the loss of documentation.
 
 ## Calling the `org2gfm` executable directly<a id="sec-4-1"></a>
 
@@ -92,7 +92,7 @@ If you like, you can scaffold a new project with the `less` template:
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#less \
-    /tmp/my-project  # or whereever you want your new project
+    /tmp/my-project  # or wherever you want your new project
 ```
 
 See the scaffolded project's `README.org` for a steps to experience `org2gfm` first-hand via a alias set up in the developer environment called `project-doc-gen`.
@@ -113,14 +113,14 @@ If you like, you can scaffold a new project with the `more` template:
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#more \
-    /tmp/my-project  # or whereever you want your new project
+    /tmp/my-project  # or wherever you want your new project
 ```
 
 See the scaffolded project's `README.org` for a steps to experience `org2gfm` first-hand via a alias set up in the developer environment called `project-doc-gen`.
 
 # Org2gfm design<a id="sec-5"></a>
 
-The `org2gfm` script provided by this project constrains the total flexibility of [Emac's Org-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html), particularly with respect to evaluation and exporting. This section discusses the design of `org2gfm` and how to use it as intended.
+The `org2gfm` script provided by this project constrains the total flexibility of [Emacs' Org-mode](https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html), particularly with respect to evaluation and exporting. This section discusses the design of `org2gfm` and how to use it as intended.
 
 ## GitHub Flavored Markdown (GFM) exporting only<a id="sec-5-1"></a>
 

--- a/doc/project-documenting.org
+++ b/doc/project-documenting.org
@@ -4,7 +4,7 @@
 * About this document
 
 This document shows one way to document your code with the =org2gfm= script
-provided by this project, Nix-project. This script converts [[org][Emac's Org-mode]]
+provided by this project, Nix-project. This script converts [[org][Emacs' Org-mode]]
 files into [[gfm][GitHub Flavored Markdown (GFM)]]. It can evaluate all source blocks in
 the Org files to generate results to include in the documentation or check that
 source code snippets work as intended.
@@ -29,7 +29,7 @@ generally want to check that these snippets are well-formed. Other times, we
 might want to process the code to obtain a result to embed in the document.
 
 Some may recognize this as similar to [[litprog][literate programming]]. The Emacs text
-editor has long has long shipped with a feature called [[org][Org-mode]] used for this
+editor has long shipped with a feature called [[org][Org-mode]] used for this
 kind of documentation. The Org-mode input files used by =org2gfm= are
 more-or-less human-readable markdown files, though they support a lot of
 features for document processing.
@@ -75,7 +75,7 @@ Module Development Guide]].
 * Usage
 
 #+begin_quote
-*_WARNING_*: Since =org2gfm by default writes over files in-place, source control
+*_WARNING_*: Since =org2gfm= by default writes over files in-place, source control
 is highly recommended to protect against the loss of documentation.
 #+end_quote
 
@@ -129,7 +129,7 @@ If you like, you can scaffold a new project with the =less= template:
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#less \
-    /tmp/my-project  # or whereever you want your new project
+    /tmp/my-project  # or wherever you want your new project
 #+end_src
 
 See the scaffolded project's =README.org= for a steps to experience =org2gfm=
@@ -156,7 +156,7 @@ If you like, you can scaffold a new project with the =more= template:
 nix --refresh \
     flake new \
     --template github:shajra/nix-project/main#more \
-    /tmp/my-project  # or whereever you want your new project
+    /tmp/my-project  # or wherever you want your new project
 #+end_src
 
 See the scaffolded project's =README.org= for a steps to experience =org2gfm=
@@ -166,7 +166,7 @@ first-hand via a alias set up in the developer environment called
 * Org2gfm design
 
 The =org2gfm= script provided by this project constrains the total flexibility
-of [[org][Emac's Org-mode]], particularly with respect to evaluation and
+of [[org][Emacs' Org-mode]], particularly with respect to evaluation and
 exporting. This section discusses the design of =org2gfm= and how to use it as
 intended.
 

--- a/examples/less/README.org
+++ b/examples/less/README.org
@@ -1,6 +1,5 @@
 #+title: Example Nix Flake-based Project Using Less
 #+link: _org https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html
-#+link: _nix-project https://github.com/shajra/nix-project
 #+link: _flake-utils https://github.com/numtide/flake-utils
 #+link: _flake-parts https://flake.parts/
 #+link: _nix-project https://github.com/shajra/nix-project
@@ -10,7 +9,7 @@ build/maintain software projects with Nix, but without library assistance like
 [[_flake-utils][flake-utils]] or [[_flake-parts][flake-parts]].
 
 This project has been configured to set up a developer environment, which you
-can enter by with =nix develop=, which enters an interactive shell.  In this
+can enter with =nix develop=, which enters an interactive shell.  In this
 shell, you'll find a few commands set up on the =PATH=:
 
 #+begin_example
@@ -20,7 +19,7 @@ shell, you'll find a few commands set up on the =PATH=:
 
   menu            - prints this menu
   project-check   - run all checks/tests/linters
-  project-doc-gen - generate Github Markdown from Org files
+  project-doc-gen - generate GitHub Markdown from Org files
   project-format  - format all files in one command
 #+end_example
 

--- a/examples/less/config.nix
+++ b/examples/less/config.nix
@@ -15,7 +15,7 @@
       }
       {
         name = "project-doc-gen";
-        help = "generate Github Markdown from Org files";
+        help = "generate GitHub Markdown from Org files";
         command = ''org2gfm-hermetic "$@"'';
       }
     ];

--- a/examples/more/README.org
+++ b/examples/more/README.org
@@ -1,6 +1,5 @@
 #+title: Example Nix Flake-based Project Using More
 #+link: _org https://www.gnu.org/software/emacs/manual/html_node/emacs/Org-Mode.html
-#+link: _nix-project https://github.com/shajra/nix-project
 #+link: _flake-parts https://flake.parts/
 #+link: _nix-project https://github.com/shajra/nix-project
 
@@ -9,7 +8,7 @@ build/maintain software projects with Nix, notably with the library assistance o
 [[_flake-parts][flake-parts]].
 
 This project has been configured to set up a developer environment, which you
-can enter by with =nix develop=, which enters an interactive shell.  In this
+can enter with =nix develop=, which enters an interactive shell.  In this
 shell, you'll find a few commands set up on the =PATH=:
 
 #+begin_example
@@ -19,10 +18,10 @@ shell, you'll find a few commands set up on the =PATH=:
 
   menu            - prints this menu
   project-check   - run all checks/tests/linters
-  project-doc-gen - generate Github Markdown from Org files
+  project-doc-gen - generate GitHub Markdown from Org files
   project-format  - format all files in one command
 #+end_example
-  [[_org][Emacs Org-mode]] files (such as this =README.org= file).
+
 
 These tools can be called with no arguments for reasonable defaults.
 

--- a/examples/more/flake.nix
+++ b/examples/more/flake.nix
@@ -72,7 +72,7 @@
                 }
                 {
                   name = "project-doc-gen";
-                  help = "generate Github Markdown from Org files";
+                  help = "generate GitHub Markdown from Org files";
                   command = ''org2gfm-hermetic "$@"'';
                 }
               ];

--- a/flake.nix
+++ b/flake.nix
@@ -73,7 +73,7 @@
               }
               {
                 name = "project-doc-gen";
-                help = "generate Github Markdown from Org files";
+                help = "generate GitHub Markdown from Org files";
                 command = ''org2gfm-hermetic "$@"'';
               }
             ];


### PR DESCRIPTION

- Standardize GitHub/macOS casing across docs and help text
- Fix alias syntax for enabling flakes via one-off alias
- Correct ~/.config/nix/nix.conf path typo
- Improve grammar (e.g., ‘there is an option’, ‘Make sure you still have…’)
- Remove duplicate links, stray fragments in example READMEs
- Fix ‘wherever’ typos and Org inline code markers
- Tidy Emacs/Org references

This PR is mostly for visibility; a deep human review is not required.
